### PR TITLE
Add cross-platform crash handler

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/eynnzerr/bandoristation/AppApplication.kt
+++ b/composeApp/src/androidMain/kotlin/com/eynnzerr/bandoristation/AppApplication.kt
@@ -3,23 +3,14 @@ package com.eynnzerr.bandoristation
 import android.annotation.SuppressLint
 import android.app.Application
 import android.content.Context
-import android.content.Intent
+import com.eynnzerr.bandoristation.installCrashHandler
 
 class AppApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         context = applicationContext
 
-        Thread.setDefaultUncaughtExceptionHandler { _, e ->
-            e.printStackTrace()
-            startActivity(
-                Intent(this, CrashActivity::class.java)
-                    .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    .apply {
-                        putExtra("msg", "platform: ${getPlatform().name} version: ${getPlatform().versionName}\n" + e.stackTraceToString())
-                    }
-            )
-        }
+        installCrashHandler()
     }
 
     companion object {

--- a/composeApp/src/androidMain/kotlin/com/eynnzerr/bandoristation/CrashHandler.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/eynnzerr/bandoristation/CrashHandler.android.kt
@@ -1,0 +1,21 @@
+package com.eynnzerr.bandoristation
+
+import android.content.Intent
+
+actual fun installCrashHandler() {
+    Thread.setDefaultUncaughtExceptionHandler { _, e ->
+        e.printStackTrace()
+        val ctx = AppApplication.context
+        ctx.startActivity(
+            Intent(ctx, CrashActivity::class.java)
+                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                .apply {
+                    putExtra(
+                        "msg",
+                        "platform: ${getPlatform().name} version: ${getPlatform().versionName}\n" +
+                            e.stackTraceToString()
+                    )
+                }
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/CrashHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/CrashHandler.kt
@@ -1,0 +1,7 @@
+package com.eynnzerr.bandoristation
+
+/**
+ * Install platform specific uncaught exception handler that presents
+ * a crash report page instead of silently terminating the app.
+ */
+expect fun installCrashHandler()

--- a/composeApp/src/desktopMain/kotlin/com/eynnzerr/bandoristation/CrashHandler.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/eynnzerr/bandoristation/CrashHandler.jvm.kt
@@ -1,0 +1,20 @@
+package com.eynnzerr.bandoristation
+
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import com.eynnzerr.bandoristation.ui.crash.CrashReportPage
+
+actual fun installCrashHandler() {
+    Thread.setDefaultUncaughtExceptionHandler { _, e ->
+        e.printStackTrace()
+        val message = "platform: ${getPlatform().name} version: ${getPlatform().versionName}\n" +
+            e.stackTraceToString()
+        application {
+            Window(onCloseRequest = ::exitApplication, title = "Crash Report") {
+                CrashReportPage(message = message) {
+                    exitApplication()
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/eynnzerr/bandoristation/main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/eynnzerr/bandoristation/main.kt
@@ -6,8 +6,10 @@ import bandoristationm.composeapp.generated.resources.Res
 import bandoristationm.composeapp.generated.resources.desktop_icon
 import io.github.vinceglb.filekit.FileKit
 import org.jetbrains.compose.resources.painterResource
+import com.eynnzerr.bandoristation.installCrashHandler
 
 fun main() = application {
+    installCrashHandler()
     FileKit.init(appId = "BandoriStation Mobile")
 
     Window(

--- a/composeApp/src/iosMain/kotlin/com/eynnzerr/bandoristation/CrashHandler.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/eynnzerr/bandoristation/CrashHandler.ios.kt
@@ -1,0 +1,21 @@
+package com.eynnzerr.bandoristation
+
+import androidx.compose.ui.window.ComposeUIViewController
+import com.eynnzerr.bandoristation.ui.crash.CrashReportPage
+import platform.UIKit.UIApplication
+import platform.UIKit.UIViewController
+import kotlin.system.setUnhandledExceptionHook
+
+actual fun installCrashHandler() {
+    setUnhandledExceptionHook { throwable ->
+        val message = "platform: ${getPlatform().name} version: ${getPlatform().versionName}\n" +
+            throwable.stackTraceToString()
+        val root = UIApplication.sharedApplication.keyWindow?.rootViewController
+        val controller = ComposeUIViewController {
+            CrashReportPage(message = message) {
+                root?.dismissViewControllerAnimated(true, null)
+            }
+        }
+        root?.presentViewController(controller, true, null)
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/eynnzerr/bandoristation/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/eynnzerr/bandoristation/MainViewController.kt
@@ -1,5 +1,10 @@
 package com.eynnzerr.bandoristation
 
 import androidx.compose.ui.window.ComposeUIViewController
+import platform.UIKit.UIViewController
+import com.eynnzerr.bandoristation.installCrashHandler
 
-fun MainViewController() = ComposeUIViewController { App() }
+fun MainViewController(): UIViewController {
+    installCrashHandler()
+    return ComposeUIViewController { App() }
+}


### PR DESCRIPTION
## Summary
- install a crash handler from common code
- create platform-specific crash handler implementations for Android, iOS and desktop
- hook crash handler installation into Android application, iOS view controller, and desktop main

## Testing
- `./gradlew :composeApp:assembleDebug` *(fails: SDK location not found)*
- `./gradlew :composeApp:desktopTest` *(fails: compilation error)*

------
https://chatgpt.com/codex/tasks/task_e_684119e68260832a95cd21b8d6e6598a