### PR TITLE
Fix chart label overflow and overlap

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/ui/component/charts/BarChart.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/ui/component/charts/BarChart.kt
@@ -453,7 +453,21 @@ private fun DrawScope.drawVerticalBarLabels(
     val barWidth = width / data.size * 0.8f
     val spacing = width / data.size * 0.2f
 
+    val sample = data.maxByOrNull { it.label.length }
+    val sampleText = sample?.let {
+        textMeasurer.measure(
+            text = it.label,
+            style = textStyle,
+            constraints = Constraints(maxWidth = barWidth.toInt())
+        )
+    }
+    val step = if (sampleText != null) {
+        max(1, ceil(sampleText.size.width / (barWidth + spacing)).toInt())
+    } else 1
+
     data.forEachIndexed { index, item ->
+        if (index % step != 0) return@forEachIndexed
+
         val x = padding + index * (barWidth + spacing) + spacing / 2 + barWidth / 2
         val y = padding + height + 16.dp.toPx()
 
@@ -463,9 +477,12 @@ private fun DrawScope.drawVerticalBarLabels(
             constraints = Constraints(maxWidth = barWidth.toInt())
         )
 
+        var xPos = x - text.size.width / 2
+        xPos = xPos.coerceIn(padding, padding + width - text.size.width)
+
         drawText(
             textLayoutResult = text,
-            topLeft = Offset(x - text.size.width / 2, y)
+            topLeft = Offset(xPos, y)
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/ui/component/charts/LineChart.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/ui/component/charts/LineChart.kt
@@ -406,11 +406,17 @@ private fun DrawScope.drawYAxisLabels(
             )
         )
 
+        val yPos = when (i) {
+            0 -> (y - text.size.height).coerceAtLeast(0f)
+            labelCount -> y.coerceAtMost(size.height - text.size.height)
+            else -> (y - text.size.height / 2).coerceIn(0f, size.height - text.size.height)
+        }
+
         drawText(
             textLayoutResult = text,
             topLeft = Offset(
                 padding - text.size.width - 8.dp.toPx(),
-                y - text.size.height / 2
+                yPos
             )
         )
     }
@@ -424,8 +430,20 @@ private fun DrawScope.drawXAxisLabels(
     textMeasurer: TextMeasurer,
     textColor: Color
 ) {
+    if (data.isEmpty()) return
+
+    val stepWidth = width / (data.size - 1)
+    val sample = data.maxByOrNull { it.label.length } ?: data.first()
+    val sampleText = textMeasurer.measure(
+        text = sample.label,
+        style = TextStyle(fontSize = 10.sp, color = textColor)
+    )
+    val step = max(1, ceil(sampleText.size.width / stepWidth).toInt())
+
     data.forEachIndexed { index, item ->
-        val x = padding + (width / (data.size - 1)) * index
+        if (index % step != 0) return@forEachIndexed
+
+        val x = padding + stepWidth * index
         val y = padding + height + 8.dp.toPx()
 
         val text = textMeasurer.measure(
@@ -436,10 +454,13 @@ private fun DrawScope.drawXAxisLabels(
             )
         )
 
+        var xPos = x - text.size.width / 2
+        xPos = xPos.coerceIn(padding, padding + width - text.size.width)
+
         drawText(
             textLayoutResult = text,
             topLeft = Offset(
-                x - text.size.width / 2,
+                xPos,
                 y
             )
         )


### PR DESCRIPTION
## Summary
- tweak chart layout logic
- clamp edge labels to stay within visible area
- skip some labels when space is too tight

## Testing
- `./gradlew tasks --all`
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429c125430832a8403e3778f7b1cce