### PR TITLE
Add continuous room upload

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/home/HomeContract.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/home/HomeContract.kt
@@ -37,7 +37,7 @@ sealed class HomeIntent: UIEvent {
     data class UpdateTimestamp(val timestampMillis: Long): HomeIntent()
     data class UpdateMessageBadge(val hasUnReadMessages: Boolean): HomeIntent()
     data class JoinRoom(val room: RoomInfo?): HomeIntent()
-    data class UploadRoom(val room: RoomUploadInfo): HomeIntent()
+    data class UploadRoom(val room: RoomUploadInfo, val continuous: Boolean = false): HomeIntent()
     data class UpdatePresetWords(val words: Set<String>): HomeIntent()
     data class AddPresetWord(val word: String): HomeIntent()
     data class RemovePresetWord(val word: String): HomeIntent()

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/home/HomeScreen.kt
@@ -210,7 +210,7 @@ fun HomeScreen(
     SendRoomDialog(
         isVisible = showSendRoomDialog,
         onDismissRequest = { viewModel.sendEffect(HomeEffect.CloseSendRoomDialog()) },
-        onSendClick = { roomInfo -> viewModel.sendEvent(UploadRoom(roomInfo)) },
+        onSendClick = { roomInfo, continuous -> viewModel.sendEvent(UploadRoom(roomInfo, continuous)) },
         onAddPresetWord = { viewModel.sendEvent(AddPresetWord(it)) },
         onDeletePresetWord = { viewModel.sendEvent(RemovePresetWord(it)) },
         presetWords = state.presetWords,

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/home/HomeViewModel.kt
@@ -36,6 +36,7 @@ import com.eynnzerr.bandoristation.utils.AppLogger
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.isActive
 
 class HomeViewModel(
     private val connectWebSocketUseCase: ConnectWebSocketUseCase,
@@ -59,6 +60,8 @@ class HomeViewModel(
     var isFilteringPJSK = true
     var isClearingOutdatedRoom = false
     var isSavingRoomHistory = true
+    var autoUploadInterval: Long = 30L
+    private var autoUploadJob: kotlinx.coroutines.Job? = null
 
     override suspend fun loadInitialData() {
         sendEvent(HomeIntent.GetRoomFilter())
@@ -143,6 +146,7 @@ class HomeViewModel(
                 isFilteringPJSK = p[PreferenceKeys.FILTER_PJSK] ?: true
                 isClearingOutdatedRoom = p[PreferenceKeys.CLEAR_OUTDATED_ROOM] ?: false
                 isSavingRoomHistory = p[PreferenceKeys.RECORD_ROOM_HISTORY] ?: true
+                autoUploadInterval = p[PreferenceKeys.AUTO_UPLOAD_INTERVAL] ?: 30L
 
                 val isFirstRun = p[PreferenceKeys.IS_FIRST_RUN] ?: true
                 internalState.update {
@@ -239,8 +243,18 @@ class HomeViewModel(
             }
 
             is HomeIntent.UploadRoom -> {
-                viewModelScope.launch {
-                    uploadRoomUseCase(event.room)
+                autoUploadJob?.cancel()
+                if (event.continuous) {
+                    autoUploadJob = viewModelScope.launch {
+                        while (kotlinx.coroutines.isActive) {
+                            uploadRoomUseCase(event.room)
+                            delay(autoUploadInterval * 1000L)
+                        }
+                    }
+                } else {
+                    viewModelScope.launch {
+                        uploadRoomUseCase(event.room)
+                    }
                 }
                 null to ShowResourceSnackbar(Res.string.upload_room_snackbar)
             }
@@ -355,6 +369,7 @@ class HomeViewModel(
 
     override fun onCleared() {
         super.onCleared()
+        autoUploadJob?.cancel()
         viewModelScope.launch { disconnectWebSocketUseCase(Unit) }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingContract.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingContract.kt
@@ -10,6 +10,7 @@ data class SettingState(
     val isClearingOutdatedRoom: Boolean = false,
     val isShowingPlayerInfo: Boolean = false,
     val isRecordingRoomHistory: Boolean = true,
+    val autoUploadInterval: Long = 30,
 ) : UIState {
     companion object {
         fun initial() = SettingState()
@@ -22,6 +23,7 @@ sealed class SettingEvent : UIEvent {
     data class UpdateClearOutdatedRoom(val isClearing: Boolean): SettingEvent()
     data class UpdateShowPlayerInfo(val isShowing: Boolean): SettingEvent()
     data class UpdateRecordRoomHistory(val isRecording: Boolean): SettingEvent()
+    data class UpdateAutoUploadInterval(val interval: Long): SettingEvent()
 }
 
 sealed class SettingEffect : UIEffect {

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -22,6 +23,7 @@ import androidx.compose.material.icons.outlined.Update
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.TopAppBarDefaults
@@ -168,6 +170,27 @@ fun SettingScreen(
                     Switch(
                         checked = state.isRecordingRoomHistory,
                         onCheckedChange = { viewModel.sendEvent(SettingEvent.UpdateRecordRoomHistory(it)) }
+                    )
+                },
+                onClick = {}
+            )
+
+            var intervalText by remember(state.autoUploadInterval) { mutableStateOf(state.autoUploadInterval.toString()) }
+            SettingItem(
+                title = "持续发车间隔(秒)",
+                desc = "自动上传房间信息的时间间隔",
+                icon = Icons.Outlined.Schedule,
+                action = {
+                    OutlinedTextField(
+                        value = intervalText,
+                        onValueChange = {
+                            intervalText = it.filter { ch -> ch.isDigit() }
+                            intervalText.toLongOrNull()?.let { v ->
+                                viewModel.sendEvent(SettingEvent.UpdateAutoUploadInterval(v))
+                            }
+                        },
+                        modifier = Modifier.width(80.dp),
+                        singleLine = true
                     )
                 },
                 onClick = {}

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingViewModel.kt
@@ -24,7 +24,8 @@ class SettingViewModel(
                     isFilteringPJSK = p[PreferenceKeys.FILTER_PJSK] ?: true,
                     isClearingOutdatedRoom = p[PreferenceKeys.CLEAR_OUTDATED_ROOM] ?: false,
                     isShowingPlayerInfo = p[PreferenceKeys.SHOW_PLAER_BRIEF] ?: false,
-                    isRecordingRoomHistory = p[PreferenceKeys.RECORD_ROOM_HISTORY] ?: true
+                    isRecordingRoomHistory = p[PreferenceKeys.RECORD_ROOM_HISTORY] ?: true,
+                    autoUploadInterval = p[PreferenceKeys.AUTO_UPLOAD_INTERVAL] ?: 30L,
                 )
             }
         }
@@ -63,6 +64,13 @@ class SettingViewModel(
             is SettingEvent.UpdateRecordRoomHistory -> {
                 viewModelScope.launch {
                     dataStore.edit { p -> p[PreferenceKeys.RECORD_ROOM_HISTORY] = event.isRecording }
+                }
+                null to null
+            }
+
+            is SettingEvent.UpdateAutoUploadInterval -> {
+                viewModelScope.launch {
+                    dataStore.edit { p -> p[PreferenceKeys.AUTO_UPLOAD_INTERVAL] = event.interval }
                 }
                 null to null
             }

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/preferences/PreferenceKeys.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/preferences/PreferenceKeys.kt
@@ -21,4 +21,5 @@ object PreferenceKeys {
     val CLEAR_OUTDATED_ROOM = booleanPreferencesKey("clear_outdated_room") // whether to auto clear outdated tooms
     val SHOW_PLAER_BRIEF = booleanPreferencesKey("show_player_brief") // whether to display player brief info in room cards
     val RECORD_ROOM_HISTORY = booleanPreferencesKey("record_room_history") // whether to record room join history
+    val AUTO_UPLOAD_INTERVAL = longPreferencesKey("auto_upload_interval") // interval(seconds) for auto uploading room info
 }

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/ui/dialog/SendRoomDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/ui/dialog/SendRoomDialog.kt
@@ -34,7 +34,7 @@ fun SendRoomDialog(
     isVisible: Boolean,
     presetWords: Set<String>,
     onDismissRequest: () -> Unit,
-    onSendClick: (uploadInfo: RoomUploadInfo) -> Unit,
+    onSendClick: (uploadInfo: RoomUploadInfo, continuous: Boolean) -> Unit,
     onAddPresetWord: (String) -> Unit,
     onDeletePresetWord: (String) -> Unit,
     prefillRoomNumber: String = "",
@@ -44,6 +44,7 @@ fun SendRoomDialog(
         var roomNumber by remember(prefillRoomNumber) { mutableStateOf(prefillRoomNumber) }
         var description by remember(prefillDescription) { mutableStateOf(prefillDescription) }
         var newPresetWord by remember { mutableStateOf("") }
+        var continuous by remember { mutableStateOf(false) }
         var isPresetWordsExpanded by remember { mutableStateOf(false) }
         var isAddWordsExpanded by remember { mutableStateOf(false) }
 
@@ -192,6 +193,16 @@ fun SendRoomDialog(
                         }
                     }
                 }
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = continuous,
+                        onCheckedChange = { continuous = it }
+                    )
+                    Text("持续发送车牌直到下次发车")
+                }
             },
             confirmButton = {
                 TextButton(
@@ -201,7 +212,7 @@ fun SendRoomDialog(
                                 number = roomNumber,
                                 description = description
                             )
-                            onSendClick(roomInfo)
+                            onSendClick(roomInfo, continuous)
                             onDismissRequest()
                         }
                     }


### PR DESCRIPTION
## Summary
- allow SendRoomDialog to request continuous uploads
- periodically upload room info when checkbox is enabled
- configure auto upload interval via settings

## Testing
- `./gradlew build -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467ad3a834832a8bc784bab9288d8a