### PR TITLE
feat(settings): show online user count from API

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -57,6 +57,11 @@
     <string name="settings_tutorial_title">术语教程</string>
     <string name="settings_tutorial_desc">关于车头常用术语的简易教程</string>
     <string name="settings_version_title">版本</string>
+    <string name="settings_online_users_title">当前在线人数</string>
+    <string name="settings_online_users_loading">正在获取在线人数...</string>
+    <string name="settings_online_users_unavailable">在线人数暂不可用</string>
+    <string name="settings_online_users_count">当前在线人数：%1$d</string>
+    <string name="settings_online_users_refresh_failed">在线人数刷新失败。</string>
     <string name="settings_encrypt_title">车牌加密</string>
     <string name="settings_encrypt_desc">他人查看车牌需取得你的同意</string>
     <string name="settings_encrypt_login_title">加密服务注册</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -57,6 +57,11 @@
     <string name="settings_tutorial_title">Terminology Tutorial</string>
     <string name="settings_tutorial_desc">A simple tutorial on common terms for room leaders</string>
     <string name="settings_version_title">Version</string>
+    <string name="settings_online_users_title">Current Online Users</string>
+    <string name="settings_online_users_loading">Loading online users...</string>
+    <string name="settings_online_users_unavailable">Online users unavailable</string>
+    <string name="settings_online_users_count">Current online users: %1$d</string>
+    <string name="settings_online_users_refresh_failed">Failed to refresh online users.</string>
     <string name="settings_encrypt_title">Encryption</string>
     <string name="settings_encrypt_desc">Others must be approved to view your room number</string>
     <string name="settings_encrypt_login_title">Registration</string>

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/data/AppRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/data/AppRepository.kt
@@ -47,6 +47,7 @@ class AppRepository(
     ) = remoteDataSource.sendAuthenticHttpsRequest(request, token)
     suspend fun sendApiRequest(request: ApiRequest) = remoteDataSource.sendApiRequest(request)
     suspend fun queryLatestRooms(latestTime: Long) = remoteDataSource.queryLatestRooms(latestTime)
+    suspend fun getOnlineNumber() = remoteDataSource.getOnlineNumber()
 
     suspend fun fetchLatestRelease(owner: String, repo: String) =
         remoteDataSource.fetchLatestRelease(owner, repo)

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/data/remote/RemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/data/remote/RemoteDataSource.kt
@@ -46,6 +46,7 @@ interface RemoteDataSource {
 
     suspend fun sendApiRequest(request: ApiRequest): ApiResponse
     suspend fun queryLatestRooms(latestTime: Long): ApiResponse
+    suspend fun getOnlineNumber(): ApiResponse
 
     suspend fun fetchLatestRelease(owner: String, repo: String): GithubRelease
 

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/data/remote/RemoteDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/data/remote/RemoteDataSourceImpl.kt
@@ -135,6 +135,9 @@ class RemoteDataSourceImpl(
     override suspend fun queryLatestRooms(latestTime: Long)
         = httpsClient.queryLatestRooms(latestTime)
 
+    override suspend fun getOnlineNumber()
+        = httpsClient.getOnlineNumber()
+
     override suspend fun fetchLatestRelease(owner: String, repo: String) =
         httpsClient.fetchLatestRelease(owner, repo)
 

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/data/remote/https/HttpsClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/data/remote/https/HttpsClient.kt
@@ -152,6 +152,35 @@ class HttpsClient(
         }
     }
 
+    suspend fun getOnlineNumber(): ApiResponse {
+        if (!isNetworkAvailable()) {
+            return ApiResponse(
+                status = "failure",
+                response = ApiResponseContent.StringContent("No Internet")
+            )
+        }
+
+        val request = GetOnlineNumberRequest(
+            function = "getOnlineNumber"
+        )
+
+        try {
+            val response: HttpResponse = client.post(apiUrl) {
+                contentType(ContentType.Application.Json)
+                setBody(request)
+            }
+
+            AppLogger.d(TAG, "getOnlineNumber status: ${response.status.value}; raw body: ${response.bodyAsText()}")
+            return response.body()
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "Error querying online number: ${e.message}")
+            return ApiResponse(
+                status = "failure",
+                response = ApiResponseContent.StringContent("Network error: ${e.message}")
+            )
+        }
+    }
+
     suspend fun fetchLatestRelease(owner: String, repo: String): GithubRelease {
         if (!isNetworkAvailable()) {
             return GithubRelease()
@@ -205,6 +234,11 @@ class HttpsClient(
 private data class QueryRoomNumberRequest(
     val function: String,
     @SerialName("latest_time") val latestTime: Long,
+)
+
+@Serializable
+private data class GetOnlineNumberRequest(
+    val function: String,
 )
 
 private const val TAG = "HttpsClient"

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/di/UseCaseModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/di/UseCaseModule.kt
@@ -34,6 +34,7 @@ import com.eynnzerr.bandoristation.usecase.account.ResetPasswordSendVCodeUseCase
 import com.eynnzerr.bandoristation.usecase.account.ResetPasswordVerifyEmailUseCase
 import com.eynnzerr.bandoristation.usecase.account.ResetPasswordUseCase
 import com.eynnzerr.bandoristation.usecase.room.GetRoomFilterUseCase
+import com.eynnzerr.bandoristation.usecase.room.GetOnlineNumberUseCase
 import com.eynnzerr.bandoristation.usecase.room.QueryLatestRoomsUseCase
 import com.eynnzerr.bandoristation.usecase.room.RequestRecentRoomsUseCase
 import com.eynnzerr.bandoristation.usecase.room.UpdateRoomFilterUseCase
@@ -275,6 +276,13 @@ fun provideUseCaseModule() = module {
             repository = get(),
             dispatcher = get(named(DispatcherQualifiers.IO_DISPATCHER)),
             dataStore = get(),
+        )
+    }
+
+    single {
+        GetOnlineNumberUseCase(
+            repository = get(),
+            dispatcher = get(named(DispatcherQualifiers.IO_DISPATCHER)),
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingContract.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingContract.kt
@@ -7,6 +7,7 @@ import com.eynnzerr.bandoristation.feature.home.HomeIntent
 import com.eynnzerr.bandoristation.getPlatform
 import com.eynnzerr.bandoristation.model.account.AccountInfo
 import com.eynnzerr.bandoristation.model.account.AccountSummary
+import org.jetbrains.compose.resources.StringResource
 
 data class SettingState(
     val themeName: String = "",
@@ -16,6 +17,8 @@ data class SettingState(
     val isRecordingRoomHistory: Boolean = true,
     val isAutoPullingNewRooms: Boolean = false,
     val autoUploadInterval: Long = 10,
+    val onlineNumber: Int? = null,
+    val isOnlineNumberLoading: Boolean = false,
     val versionName: String = "",
     val isEncryptionEnabled: Boolean = false,
     val encryptionValidDays: Long = 0,
@@ -40,6 +43,7 @@ sealed class SettingEvent : UIEvent {
     data class UpdateRecordRoomHistory(val isRecording: Boolean): SettingEvent()
     data class UpdateAutoPullNewRooms(val enabled: Boolean): SettingEvent()
     data class UpdateAutoUploadInterval(val interval: Long): SettingEvent()
+    class FetchOnlineNumber: SettingEvent()
     data class UpdateEnableEncryption(val enabled: Boolean): SettingEvent()
     class RegisterEncryption: SettingEvent()
     data class UpdateInviteCode(val code: String): SettingEvent()
@@ -55,4 +59,5 @@ sealed class SettingEffect : UIEffect {
     data class ControlListDialog(val isShowing: Boolean): SettingEffect()
     data class ControlProfileDialog(val isShowing: Boolean): SettingEffect()
     data class ShowSnackbar(val text: String): SettingEffect()
+    data class ShowResourceSnackbar(val textRes: StringResource): SettingEffect()
 }

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.outlined.Block
 import androidx.compose.material.icons.outlined.Error
 import androidx.compose.material.icons.outlined.GroupAdd
 import androidx.compose.material.icons.outlined.Palette
+import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.SaveAlt
 import androidx.compose.material.icons.outlined.Schedule
@@ -55,6 +56,10 @@ import bandoristationm.composeapp.generated.resources.settings_basic_settings
 import bandoristationm.composeapp.generated.resources.settings_encryption_valid_days
 import bandoristationm.composeapp.generated.resources.settings_error_icon_desc
 import bandoristationm.composeapp.generated.resources.settings_extended_features
+import bandoristationm.composeapp.generated.resources.settings_online_users_count
+import bandoristationm.composeapp.generated.resources.settings_online_users_loading
+import bandoristationm.composeapp.generated.resources.settings_online_users_title
+import bandoristationm.composeapp.generated.resources.settings_online_users_unavailable
 import bandoristationm.composeapp.generated.resources.settings_no_data
 import bandoristationm.composeapp.generated.resources.settings_other
 import bandoristationm.composeapp.generated.resources.settings_screen_title
@@ -74,6 +79,7 @@ import bandoristationm.composeapp.generated.resources.settings_encrypt_code_desc
 import bandoristationm.composeapp.generated.resources.settings_encrypt_code_title
 import bandoristationm.composeapp.generated.resources.settings_encrypt_list_desc
 import bandoristationm.composeapp.generated.resources.settings_encrypt_list_title
+import bandoristationm.composeapp.generated.resources.home_refresh_icon_desc
 import bandoristationm.composeapp.generated.resources.settings_tutorial_title
 import bandoristationm.composeapp.generated.resources.settings_tutorial_desc
 import bandoristationm.composeapp.generated.resources.settings_version_title
@@ -92,6 +98,7 @@ import com.eynnzerr.bandoristation.ui.ext.appBarScroll
 import com.eynnzerr.bandoristation.ui.theme.bandThemeList
 import com.eynnzerr.bandoristation.utils.rememberFlowWithLifecycle
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -132,6 +139,15 @@ fun SettingScreen(
                     coroutineScope.launch {
                         snackbarHostState.showSnackbar(
                             message = action.text,
+                            duration = SnackbarDuration.Short
+                        )
+                    }
+                }
+
+                is SettingEffect.ShowResourceSnackbar -> {
+                    coroutineScope.launch {
+                        snackbarHostState.showSnackbar(
+                            message = getString(action.textRes),
                             duration = SnackbarDuration.Short
                         )
                     }
@@ -198,6 +214,18 @@ fun SettingScreen(
                         )
                     }
                 },
+                actions = {
+                    IconButton(
+                        onClick = {
+                            viewModel.sendEvent(FetchOnlineNumber())
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Refresh,
+                            contentDescription = stringResource(Res.string.home_refresh_icon_desc)
+                        )
+                    }
+                }
             )
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
@@ -371,6 +399,20 @@ fun SettingScreen(
             )
 
             SettingsGroup {
+                SettingItem(
+                    title = stringResource(Res.string.settings_online_users_title),
+                    desc = when {
+                        state.onlineNumber != null ->
+                            stringResource(Res.string.settings_online_users_count, state.onlineNumber ?: 0)
+                        state.isOnlineNumberLoading ->
+                            stringResource(Res.string.settings_online_users_loading)
+                        else ->
+                            stringResource(Res.string.settings_online_users_unavailable)
+                    },
+                    icon = Icons.Outlined.People,
+                    onClick = { viewModel.sendEvent(FetchOnlineNumber()) }
+                )
+
                 SettingItem(
                     title = stringResource(Res.string.settings_tutorial_title),
                     desc = stringResource(Res.string.settings_tutorial_desc),

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/feature/settings/SettingViewModel.kt
@@ -4,6 +4,8 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.viewModelScope
+import bandoristationm.composeapp.generated.resources.Res
+import bandoristationm.composeapp.generated.resources.settings_online_users_refresh_failed
 import com.eynnzerr.bandoristation.base.BaseViewModel
 import com.eynnzerr.bandoristation.feature.settings.SettingEffect.*
 import com.eynnzerr.bandoristation.model.UseCaseResult
@@ -15,6 +17,7 @@ import com.eynnzerr.bandoristation.usecase.encryption.RegisterEncryptionUseCase
 import com.eynnzerr.bandoristation.usecase.encryption.RemoveFromBlacklistUseCase
 import com.eynnzerr.bandoristation.usecase.encryption.RemoveFromWhitelistUseCase
 import com.eynnzerr.bandoristation.usecase.encryption.UpdateInviteCodeUseCase
+import com.eynnzerr.bandoristation.usecase.room.GetOnlineNumberUseCase
 import com.eynnzerr.bandoristation.usecase.social.FollowUserUseCase
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -29,11 +32,14 @@ class SettingViewModel(
     private val getBlackWhiteListUseCase: GetBlackWhiteListUseCase,
     private val getUserInfoUseCase: GetUserInfoUseCase,
     private val followUserUseCase: FollowUserUseCase,
+    private val getOnlineNumberUseCase: GetOnlineNumberUseCase,
     private val dataStore: DataStore<Preferences>,
 ) : BaseViewModel<SettingState, SettingEvent, SettingEffect>(
     initialState = SettingState.initial()
 ) {
     override suspend fun onInitialize() {
+        sendEvent(SettingEvent.FetchOnlineNumber())
+
         dataStore.data.collect { p ->
             val currentTimestamp = Clock.System.now().toEpochMilliseconds()
             val registerExpireTimestamp = p[PreferenceKeys.REGISTER_EXPIRE_TIME] ?: currentTimestamp
@@ -104,6 +110,28 @@ class SettingViewModel(
             is SettingEvent.UpdateAutoUploadInterval -> {
                 viewModelScope.launch {
                     dataStore.edit { p -> p[PreferenceKeys.AUTO_UPLOAD_INTERVAL] = event.interval }
+                }
+                null to null
+            }
+
+            is SettingEvent.FetchOnlineNumber -> {
+                internalState.update { it.copy(isOnlineNumberLoading = true) }
+                viewModelScope.launch {
+                    when (val response = getOnlineNumberUseCase.invoke(Unit)) {
+                        is UseCaseResult.Loading -> Unit
+                        is UseCaseResult.Error -> {
+                            internalState.update { it.copy(isOnlineNumberLoading = false) }
+                            sendEffect(ShowResourceSnackbar(Res.string.settings_online_users_refresh_failed))
+                        }
+                        is UseCaseResult.Success -> {
+                            internalState.update {
+                                it.copy(
+                                    onlineNumber = response.data,
+                                    isOnlineNumberLoading = false
+                                )
+                            }
+                        }
+                    }
                 }
                 null to null
             }

--- a/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/usecase/room/GetOnlineNumberUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/eynnzerr/bandoristation/usecase/room/GetOnlineNumberUseCase.kt
@@ -1,0 +1,33 @@
+package com.eynnzerr.bandoristation.usecase.room
+
+import com.eynnzerr.bandoristation.data.AppRepository
+import com.eynnzerr.bandoristation.data.remote.websocket.NetResponseHelper
+import com.eynnzerr.bandoristation.model.UseCaseResult
+import com.eynnzerr.bandoristation.usecase.base.UseCase
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+class GetOnlineNumberUseCase(
+    private val repository: AppRepository,
+    dispatcher: CoroutineDispatcher,
+) : UseCase<Unit, Int, String>(dispatcher) {
+
+    override suspend fun execute(parameters: Unit): UseCaseResult<Int, String> {
+        repository.getOnlineNumber().handle(
+            onSuccess = { responseContent ->
+                val payload = NetResponseHelper.parseApiResponse<OnlineNumberResponse>(responseContent)
+                return payload?.let { UseCaseResult.Success(it.onlineNumber) }
+                    ?: UseCaseResult.Error("Failed to parse getOnlineNumber response.")
+            },
+            onFailure = {
+                return UseCaseResult.Error(it)
+            }
+        )
+    }
+}
+
+@Serializable
+private data class OnlineNumberResponse(
+    @SerialName("online_number") val onlineNumber: Int,
+)


### PR DESCRIPTION
## Summary
- add online user count API call (POST https://api.bandoristation.com with function=getOnlineNumber)
- wire repository + remote data source + new use case for parsing response.online_number
- display current online users in Settings with initial load and manual refresh
- keep last successful value on failure and show refresh-failed snackbar
- add i18n strings for EN/zh-CN

## Validation
- ./gradlew :composeApp:assembleDebug --console=plain
- BUILD SUCCESSFUL
